### PR TITLE
fix mismatched case of variable "app"

### DIFF
--- a/nginx-pre-reload
+++ b/nginx-pre-reload
@@ -13,7 +13,7 @@ eval "$(config_export app "$app")"
 
 max_upload_size="$MAX_UPLOAD_SIZE"
 
-CONFIG_FOLDER="$DOKKU_ROOT/$APP/nginx.conf.d"
+CONFIG_FOLDER="$DOKKU_ROOT/$app/nginx.conf.d"
 CONFIG_FILE="$CONFIG_FOLDER/upload.conf"
 [[ -d "$CONFIG_FOLDER" ]] || mkdir "$CONFIG_FOLDER"
 


### PR DESCRIPTION
In dokku version 0.12.5 this plugin fails because it creates in
`/home/dokku//nginx.conf.d/upload.conf`
instead of
`/home/dokku/myapp/nginx.conf.d/upload.conf`.
I do not know how it could work before, however with this fix works for me now.
